### PR TITLE
Proper structure of engines, using `,` separation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "x-ray"
   ],
   "engines": {
-    "node": ">=6.0.0 <7.0.0"
+    "node": "^6.0.0, ^8.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The wrong structure was used for engine comparison.  My apologizes.

Tested, this works properly.